### PR TITLE
Enforce numpy-style docstrings via ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,14 @@ line-length = 120
 indent-width = 4
 
 [tool.ruff.lint]
-select = ["E", "F", "UP", "I"]
+select = ["E", "F", "UP", "I", "D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+# Tests don't require docstrings.
+"test/*" = ["D100", "D101", "D102", "D103", "D104"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/webpower/anova_classes.py
+++ b/webpower/anova_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for ANOVA designs."""
+
 from math import ceil, sqrt
 
 from scipy.stats import chi2, ncf, nct, ncx2
@@ -8,6 +10,29 @@ from webpower.utils import bisect, brentq
 
 
 class WpAnovaClass:
+    """Power analysis for one-way ANOVA.
+
+    One-way analysis of variance (one-way ANOVA) is a technique used to compare means of two or more groups. The
+    ANOVA tests the null hypothesis that samples in two or more groups are drawn from populations with the same mean
+    values, typically producing an F-statistic, the ratio of the between-group variance to the within-group variance.
+
+    Parameters
+    ----------
+    k : int, default=None
+        Number of groups
+    n : int, default=None
+        Sample size
+    f : float, default=None
+        Effect size
+    alpha : float, default=None
+        Significance level of the test
+    power : float, default=None
+        Statistical power
+    test_type : {'overall', 'two-sided', 'greater', 'less'}, default='overall'
+        The option "overall" is for the overall test of anova; "two-sided" is for a contrast anova; "greater" is
+        testing the between-group variance greater than the within-group, while "less" is vice versa.
+    """
+
     def __init__(
         self,
         k: int | None = None,
@@ -184,6 +209,12 @@ class WpAnovaClass:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing k, n, the effect size, alpha, power, and metadata (method, note, url).
+        """
         if self.power is None:
             if self.n is None or self.f is None or self.k is None or self.alpha is None:
                 raise ValueError("n, f, k, and alpha must be provided to compute power")
@@ -221,6 +252,26 @@ class WpAnovaClass:
 
 
 class WpAnovaBinaryClass:
+    """Power analysis for one-way ANOVA with binary data.
+
+    The power analysis procedure for one-way ANOVA with binary data is introduced by Mai and Zhang (2017). One-way
+    ANOVA with binary data is used for comparing means of three or more groups of binary data. Its outcome variable
+    is supposed to follow Bernoulli distribution, and its overall test uses a likelihood ratio test statistic.
+
+    Parameters
+    ----------
+    k : int, default=None
+        Number of groups
+    n : int, default=None
+        Sample size
+    V : float, default=None
+        Effect size
+    alpha : float, default=None
+        Significance level of the test
+    power : float, default=None
+        Statistical power
+    """
+
     def __init__(
         self,
         k: int | None = None,
@@ -274,6 +325,12 @@ class WpAnovaBinaryClass:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing k, n, the effect size, alpha, power, and metadata (method, note, url).
+        """
         if self.power is None:
             if self.V is None or self.n is None or self.k is None or self.alpha is None:
                 raise ValueError("V, n, k, and alpha must be provided to compute power")
@@ -311,6 +368,26 @@ class WpAnovaBinaryClass:
 
 
 class WpAnovaCountClass(WpAnovaBinaryClass):
+    """Power analysis for one-way ANOVA with count data.
+
+    The power analysis procedure for one-way ANOVA with count data is introduced by Mai and Zhang (2017). One-way
+    ANOVA with count data is used for comparing means of three or more groups of count data. Its outcome variable is
+    supposed to follow Poisson distribution, and its overall test uses a likelihood ratio test statistic.
+
+    Parameters
+    ----------
+    k : int, default=None
+        Number of groups
+    n : int, default=None
+        Sample size
+    V : float, default=None
+        Effect size
+    alpha : float, default=None
+        Significance level of the test
+    power : float, default=None
+        Statistical power
+    """
+
     def __init__(
         self,
         k: int | None = None,
@@ -326,6 +403,24 @@ class WpAnovaCountClass(WpAnovaBinaryClass):
 
 
 class WpKAnovaClass:
+    """Power analysis for k-way ANOVA.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size
+    ndf : int, default=None
+        Numerator degrees of freedom
+    f : float, default=None
+        Effect size
+    ng : int, default=None
+        Number of groups
+    alpha : float, default=None
+        Significance level of the test
+    power : float, default=None
+        Statistical power
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -382,6 +477,12 @@ class WpKAnovaClass:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, ndf, ddf, the effect size, ng, alpha, power, and metadata (method, note, url).
+        """
         if self.power is None:
             if self.f is None or self.n is None or self.ng is None or self.ndf is None or self.alpha is None:
                 raise ValueError("f, n, ng, ndf, and alpha must be provided to compute power")
@@ -431,6 +532,39 @@ class WpKAnovaClass:
 
 
 class WpRMAnovaClass:
+    """Power analysis for repeated-measures ANOVA.
+
+    Repeated-measures ANOVA can be used to compare the means of a sequence of measurements. In a repeated-measures
+    design, every subject is exposed to all different treatments, or more commonly measured across different time
+    points. Power analysis is available for the within-effect test about the mean difference among measurements, the
+    between-effect test about mean difference among groups, and the interaction effect test of measurements and groups.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size
+    ng : int, default=None
+        Number of groups
+    nm : int, default=None
+        Number of measurements
+    f : float, default=None
+        Effect size. We use the statistic f as the measure of effect size for repeated measures ANOVA
+        as in Cohen (1988, p.275).
+    nscor : float, default=1
+        Nonsphericity correction coefficient. The nonsphericity correction coefficient is a measure of the degree of
+        sphericity in the population. A coefficient of 1 means sphericity is met, while a coefficient less than 1 means
+        not met. The smaller value of the coefficient means the further departure from sphericity. The lowest value of
+        the coefficient is 1/(nm-1) where nm is the total number of measurements. Two viable approaches for computing
+        the empirical nonsphericity correction coefficient are suggested. One is by Greenhouse and Geisser (1959),
+        the other is by Huynh and Feldt (1976).
+    alpha : float, default=None
+        Significance level of the test
+    power : float, default=None
+        Statistical power
+    test_type : {'between', 'within', 'interaction'}, default='between'
+        Type of analysis.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -543,6 +677,12 @@ class WpRMAnovaClass:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, nm, the effect size, nscor, ng, alpha, power, and metadata (method, note, url).
+        """
         if self.power is None:
             if self.f is None or self.n is None or self.ng is None or self.nm is None or self.alpha is None:
                 raise ValueError("f, n, ng, nm, and alpha must be provided to compute power")

--- a/webpower/misc_classes.py
+++ b/webpower/misc_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for correlation and mediation models."""
+
 from math import ceil, log, sqrt
 
 from scipy.stats import norm
@@ -6,6 +8,33 @@ from webpower.utils import brentq, nuniroot
 
 
 class WpMediation:
+    """Power analysis for simple mediation models.
+
+    Mediation models can be used to investigate the underlying mechanisms related to why an input variable x
+    influences an output variable y. The mediation effect is calculated as a*b, where a is the path coefficent from
+    the predictor x to the mediator m, and b is the path coefficent from the mediator m to the outcome variable y.
+    The Sobel test statistic is used to test whether the mediation effect is significantly different from zero.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size
+    power : float, default=None
+        Statistical power
+    a : float, default=None
+        Coefficient from x to m
+    b : float, default=None
+        Coefficient from m to y
+    var_x : float, default=1
+        Variance of x
+    var_y : float, default=None
+        Variance of y
+    var_m : float, default=1
+        Variance of m
+    alpha : float, default=None
+        Significance level chosen for the test
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -95,6 +124,12 @@ class WpMediation:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, a, b, var_x, var_y, var_m, alpha, power and metadata for the test.
+        """
         if self.power is None:
             if self.n is None or self.a is None or self.b is None or self.var_y is None or self.alpha is None:
                 raise ValueError("n, a, b, var_y, and alpha must be provided to compute power")
@@ -142,6 +177,31 @@ class WpMediation:
 
 
 class WpCorrelation:
+    """Power analysis for correlation.
+
+    Correlation measures whether and how a pair of variables are related. The Pearson Product Moment correlation
+    coefficient (r) is adopted here. The power calculation for correlation is conducted based on Fisher's z
+    transformation of the Pearson correlation coefficient.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size
+    r : float, default=None
+        Effect size or correlation. According to Cohen (1988), a correlation coefficient of 0.10, 0.30, and 0.50 are
+        considered as an effect size of "small", "medium", and "large", respectively.
+    power : float, default=None
+        Statistical power
+    p : int, default=0
+        Number of variables to partial out
+    rho0 : float, default=0.0
+        Null correlation coefficient
+    alpha : float, default=None
+        Significance level chosen for the test
+    alternative : {'two-sided', 'greater', 'less'}, default='two-sided'
+        Direction of the alternative hypothesis.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -266,6 +326,12 @@ class WpCorrelation:
         return float(norm.cdf((-delta - z_alpha) / sqrt(v)) - power)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, effect_size, alpha, power, the alternative hypothesis and metadata for the test.
+        """
         if self.power is None:
             if self.n is None or self.r is None or self.alpha is None:
                 raise ValueError("n, r, and alpha must be provided to compute power")

--- a/webpower/power_tests.py
+++ b/webpower/power_tests.py
@@ -1,3 +1,5 @@
+"""Public power-analysis functions wrapping the WebPower test classes."""
+
 from webpower.anova_classes import (
     WpAnovaBinaryClass,
     WpAnovaClass,
@@ -22,7 +24,9 @@ def wp_anova_test(
     test_type: str = "overall",
     print_pretty: bool = True,
 ) -> dict:
-    """One-way analysis of variance (one-way ANOVA) is a technique used to compare means of two or more groups (e.g.,
+    """Conduct power analysis for one-way ANOVA.
+
+    One-way analysis of variance (one-way ANOVA) is a technique used to compare means of two or more groups (e.g.,
     Maxwell & Delaney, 2003). The ANOVA tests the null hypothesis that samples in two or more groups are drawn from
     populations with the same mean values. The ANOVA analysis typically produces an F-statistic, the ratio of the
     between-group variance to the within-group variance.
@@ -109,7 +113,9 @@ def wp_anova_binary_test(
     power: float | None = None,
     print_pretty: bool = True,
 ) -> dict:
-    """The power analysis procedure for one-way ANOVA with binary data is introduced by Mai and Zhang (2017). One-way
+    """Conduct power analysis for one-way ANOVA with binary data.
+
+    The power analysis procedure for one-way ANOVA with binary data is introduced by Mai and Zhang (2017). One-way
     ANOVA with binary data is used for comparing means of three or more groups of binary data. Its outcome variable is
     supposed to follow Bernoulli distribution. And its overall test uses a likelihood ratio test statistics.
 
@@ -187,7 +193,9 @@ def wp_anova_count_test(
     power: float | None = None,
     print_pretty: bool = True,
 ) -> dict:
-    """The power analysis procedure for one-way ANOVA with count data is introduced by Mai and Zhang (2017). One-way
+    """Conduct power analysis for one-way ANOVA with count data.
+
+    The power analysis procedure for one-way ANOVA with count data is introduced by Mai and Zhang (2017). One-way
     ANOVA with count data is used for comparing means of three or more groups of binary data. Its outcome variable is
     supposed to follow Poisson distribution. And its overall test uses a likelihood ratio test statistics.
 
@@ -357,7 +365,9 @@ def wp_rmanova_test(
     test_type: str = "between",
     print_pretty: bool = True,
 ) -> dict:
-    """Repeated-measures ANOVA can be used to compare the means of a sequence of measurements(e.g., O’brien & Kaiser,
+    """Conduct power analysis for repeated-measures ANOVA.
+
+    Repeated-measures ANOVA can be used to compare the means of a sequence of measurements(e.g., O’brien & Kaiser,
     1985). In a repeated-measures design, every subject is exposed to all different treatments, or more commonly
     measured across different time points. Power analysis for (1)the within-effect test about the mean difference among
     measurements by default. If the subjects are from more than one group, the power analysis is also available for (2)
@@ -463,7 +473,9 @@ def wp_one_prop_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """Tests of proportions are a technique used to compare proportions of success or agreement in one or two samples.
+    """Conduct power analysis for a one-sample proportion test.
+
+    Tests of proportions are a technique used to compare proportions of success or agreement in one or two samples.
     The one-sample test of proportion tests the null proportion of success, usually 0.5. The power calculation is based
     on the arcsine transformation of the proportion (see Cohen, 1988, p.548).
 
@@ -539,7 +551,9 @@ def wp_two_prop_one_n_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """Tests of proportions are a technique used to compare proportions of success or agreement in one or two samples.
+    """Conduct power analysis for a two-sample proportion test with equal sample sizes.
+
+    Tests of proportions are a technique used to compare proportions of success or agreement in one or two samples.
     The two-sample test of proportions tests the null hypothesis that the two samples are drawn from populations with
     the same proportion of success. The power calculation is based on the arcsine transformation of the proportion (see
     Cohen, 1988, p.548).
@@ -617,7 +631,9 @@ def wp_two_prop_two_n_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """Tests of proportions are a technique used to compare proportions of success or agreement in one or two samples.
+    """Conduct power analysis for a two-sample proportion test with unequal sample sizes.
+
+    Tests of proportions are a technique used to compare proportions of success or agreement in one or two samples.
     The two-sample test of proportions tests the null hypothesis that the two samples are drawn from populations with
     the same proportion of success. The power calculation is based on the arcsine transformation of the proportion (see
     Cohen, 1988, p.548).
@@ -706,7 +722,9 @@ def wp_t1_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """A t-test is a statistical hypothesis test in which the test statistic follows a Student’s t distribution if the
+    """Conduct power analysis for a one-sample or paired t-test.
+
+    A t-test is a statistical hypothesis test in which the test statistic follows a Student’s t distribution if the
     null hypothesis is true and follows a non-central t distribution if the alternative hypothesis is true. The t test
     can assess the statistical significance of (1) the difference between population mean and a specific value, (2) the
     difference between two independent population means, and (3) difference between means of matched pairs.
@@ -814,7 +832,9 @@ def wp_t2_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """A t-test is a statistical hypothesis test in which the test statistic follows a Student’s t distribution if the
+    """Conduct power analysis for a two-sample t-test.
+
+    A t-test is a statistical hypothesis test in which the test statistic follows a Student’s t distribution if the
     null hypothesis is true and follows a non-central t distribution if the alternative hypothesis is true. The t test
     can assess the statistical significance of (1) the difference between population mean and a specific value, (2) the
     difference between two independent population means, and (3) difference between means of matched pairs.
@@ -901,7 +921,9 @@ def wp_regression_test(
     test_type: str = "regular",
     print_pretty: bool = True,
 ) -> dict:
-    """This function is for power analysis for regression models. Regression is a statistical technique for examining
+    """Conduct power analysis for linear regression models.
+
+    This function is for power analysis for regression models. Regression is a statistical technique for examining
     the relationship between one or more independent variables (or predictors) and one dependent variable (or the
     outcome). Regression provides an F-statistic that can be formulated using the ratio between variation in the outcome
     variable that is explained by the predictors and the unexplained variation (Cohen, 1988)). The test statistic can
@@ -998,7 +1020,9 @@ def wp_poisson_test(
     parameter: int | float | list | tuple | None = None,
     print_pretty: bool = True,
 ) -> dict:
-    """This function is for Poisson regression models. Poisson regression is a type of generalized linear models where
+    """Conduct power analysis for Poisson regression models.
+
+    This function is for Poisson regression models. Poisson regression is a type of generalized linear models where
     the outcomes are usually count data. Here, Maximum likelihood methods is used to estimate the model parameters. The
     estimated regression coefficient is assumed to follow a normal distribution. A Wald test is used to test the mean
     difference between the estimated parameter and the null parameter (typically the null hypothesis assumes it equals
@@ -1096,7 +1120,9 @@ def wp_logistic_test(
     parameter: int | float | list | tuple | None = None,
     print_pretty: bool = True,
 ) -> dict:
-    """This function is for Logistic regression models. Logistic regression is a type of generalized linear models where
+    """Conduct power analysis for logistic regression models.
+
+    This function is for Logistic regression models. Logistic regression is a type of generalized linear models where
     the outcome variable follows Bernoulli distribution. Here, Maximum likelihood methods is used to estimate the model
     parameters. The estimated regression coefficient is assumed to follow a normal distribution. A Wald test is used to
     test the mean difference between the estimated parameter and the null parameter (typically the null hypothesis
@@ -1186,7 +1212,9 @@ def wp_sem_chisq_test(
     power: float | None = None,
     print_pretty: bool = True,
 ) -> dict:
-    """Structural equation modeling (SEM) is a multivariate technique used to analyze relationships among observed and
+    """Conduct power analysis for SEM based on the chi-squared test.
+
+    Structural equation modeling (SEM) is a multivariate technique used to analyze relationships among observed and
     latent variables. It can be viewed as a combination of factor analysis and multivariate regression analysis. Two
     methods are widely used in power analysis for SEM. One is based on the likelihood ratio test proposed by Satorra and
     Saris (1985). The other is based on RMSEA proposed by MacCallum et al. (1996). This function is for SEM power
@@ -1265,7 +1293,9 @@ def wp_sem_rmsea_test(
     test_type: str = "close",
     print_pretty: bool = True,
 ) -> dict:
-    """Structural equation modeling (SEM) is a multivariate technique used to analyze relationships among observed and
+    """Conduct power analysis for SEM based on RMSEA.
+
+    Structural equation modeling (SEM) is a multivariate technique used to analyze relationships among observed and
     latent variables. It can be viewed as a combination of factor analysis and multivariate regression analysis. Two
     methods are widely used in power analysis for SEM. One is based on the likelihood ratio test proposed by Satorra and
     Saris (1985). The other is based on RMSEA proposed by MacCallum et al. (1996). This function is for SEM power
@@ -1352,7 +1382,9 @@ def wp_mediation_test(
     alpha: float | None = None,
     print_pretty: bool = True,
 ) -> dict:
-    """This function is for mediation models. Mediation models can be used to investigate the underlying mechanisms
+    """Conduct power analysis for mediation models.
+
+    This function is for mediation models. Mediation models can be used to investigate the underlying mechanisms
     related to why an input variable x influences an output variable y (e.g., Hayes, 2013; MacKinnon, 2008). The
     mediation effect is calculated as a*b, where a is the path coefficent from the predictor x to the mediator m, and b
     is the path coefficent from the mediator m to the outcome variable y. Sobel test statistic (Sobel, 1982) is used to
@@ -1446,7 +1478,9 @@ def wp_correlation_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """This function is for power analysis for correlation. Correlation measures whether and how a pair of variables are
+    """Conduct power analysis for correlation.
+
+    This function is for power analysis for correlation. Correlation measures whether and how a pair of variables are
     related. The Pearson Product Moment correlation coefficient (r) is adopted here. The power calculation for
     correlation is conducted based on Fisher’s z transformation of Pearson correlation coefficient (Fisher, 1915, 1921).
 
@@ -1524,7 +1558,9 @@ def wp_mrt2arm_test(
     test_type: str = "main",
     print_pretty: bool = True,
 ) -> dict:
-    """Multisite randomized trials (MRT) are a type of multilevel design for the situation when the entire cluster is
+    """Conduct power analysis for two-arm multisite randomized trials (MRT).
+
+    Multisite randomized trials (MRT) are a type of multilevel design for the situation when the entire cluster is
     randomly assigned to either a treatment arm or a control arm (Liu, 2013). The data from MRT can be analyzed in a
     two-level hierarchical linear model, where the indicator variable for treatment assignment is included in first
     level. If a study contains multiple treatments, then multiple indicators will be used. This function is for designs
@@ -1600,7 +1636,9 @@ def wp_mrt3arm_test(
     test_type: str = "main",
     print_pretty: bool = True,
 ) -> dict:
-    """Multisite randomized trials (MRT) are a type of multilevel design for the situation when the entire cluster is
+    """Conduct power analysis for three-arm multisite randomized trials (MRT).
+
+    Multisite randomized trials (MRT) are a type of multilevel design for the situation when the entire cluster is
     randomly assigned to either a treatment arm or a control arm (Liu, 2013). The data from MRT can be analyzed in a
     two-level hierarchical linear model, where the indicator variable for treatment assignment is included in first
     level. If a study contains multiple treatments, then multiple indicators will be used. This function is for designs
@@ -1725,7 +1763,9 @@ def wp_crt2arm_test(
     alternative: str = "two-sided",
     print_pretty: bool = True,
 ) -> dict:
-    """Cluster randomized trials (CRT) are a type of multilevel design for the situation when the entire cluster is
+    """Conduct power analysis for two-arm cluster randomized trials (CRT).
+
+    Cluster randomized trials (CRT) are a type of multilevel design for the situation when the entire cluster is
     randomly assigned to either a treatment arm or a contral arm (Liu, 2013). The data from CRT can be analyzed in a
     two-level hierachical linear model, where the indicator variable for treatment assignment is included in second
     level. If a study contains multiple treatments, then mutiple indicators will be used. This function is for designs
@@ -1824,7 +1864,9 @@ def wp_crt3arm_test(
     test_type: str = "main",
     print_pretty: bool = True,
 ) -> dict:
-    """Cluster randomized trials (CRT) are a type of multilevel design for the situation when the entire cluster is
+    """Conduct power analysis for three-arm cluster randomized trials (CRT).
+
+    Cluster randomized trials (CRT) are a type of multilevel design for the situation when the entire cluster is
     randomly assigned to either a treatment arm or a contral arm (Liu, 2013). The data from CRT can be analyzed in a
     two-level hierachical linear model, where the indicator variable for treatment assignment is included in second
     level. If a study contains multiple treatments, then mutiple indicators will be used. This function is for designs

--- a/webpower/proportion_classes.py
+++ b/webpower/proportion_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for tests of proportions."""
+
 from math import ceil, sqrt
 
 from scipy.stats import norm
@@ -6,6 +8,26 @@ from webpower.utils import brentq
 
 
 class WpOneProp:
+    """Power analysis for a one-sample proportion test.
+
+    The one-sample test of proportion tests the null proportion of success, usually 0.5. The power calculation is
+    based on the arcsine transformation of the proportion (see Cohen, 1988, p.548).
+
+    Parameters
+    ----------
+    h : float, default=None
+        Effect size of the proportion comparison. Cohen (1992) suggested that effect size values of 0.2, 0.5, and 0.8
+        represent "small", "medium", and "large" effect sizes, respectively.
+    n : int, default=None
+        The sample size of the group.
+    alpha : float, default=None
+        Significance level of the test.
+    power : float, default=None
+        Statistical power.
+    alternative : {'two-sided', 'greater', 'less'}
+        Direction of the alternative hypothesis.
+    """
+
     def __init__(
         self,
         h: float | None,
@@ -60,6 +82,12 @@ class WpOneProp:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing the effect size, n, alpha, power, alternative hypothesis, and test metadata.
+        """
         if self.power is None:
             if self.h is None or self.n is None or self.alpha is None:
                 raise ValueError("h, n, and alpha must be provided to compute power")
@@ -97,6 +125,27 @@ class WpOneProp:
 
 
 class WpTwoPropOneN:
+    """Power analysis for a two-sample proportion test with equal sample sizes.
+
+    The two-sample test of proportions tests the null hypothesis that the two samples are drawn from populations with
+    the same proportion of success. The power calculation is based on the arcsine transformation of the proportion
+    (see Cohen, 1988, p.548).
+
+    Parameters
+    ----------
+    h : float, default=None
+        Effect size of the proportion comparison. Cohen (1992) suggested that effect size values of 0.2, 0.5, and 0.8
+        represent "small", "medium", and "large" effect sizes, respectively.
+    n : int, default=None
+        The sample size of the group.
+    alpha : float, default=None
+        Significance level of the test.
+    power : float, default=None
+        Statistical power.
+    alternative : {'two-sided', 'greater', 'less'}
+        Direction of the alternative hypothesis.
+    """
+
     def __init__(
         self,
         h: float | None,
@@ -157,6 +206,12 @@ class WpTwoPropOneN:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing the effect size, n, alpha, power, alternative hypothesis, and test metadata.
+        """
         if self.power is None:
             if self.h is None or self.n is None or self.alpha is None:
                 raise ValueError("h, n, and alpha must be provided to compute power")
@@ -194,6 +249,29 @@ class WpTwoPropOneN:
 
 
 class WpTwoPropTwoN:
+    """Power analysis for a two-sample proportion test with unequal sample sizes.
+
+    The two-sample test of proportions tests the null hypothesis that the two samples are drawn from populations with
+    the same proportion of success. The power calculation is based on the arcsine transformation of the proportion
+    (see Cohen, 1988, p.548).
+
+    Parameters
+    ----------
+    h : float, default=None
+        Effect size of the proportion comparison. Cohen (1992) suggested that effect size values of 0.2, 0.5, and 0.8
+        represent "small", "medium", and "large" effect sizes, respectively.
+    n1 : int, default=None
+        The sample size of the first group.
+    n2 : int, default=None
+        The sample size of the second group.
+    alpha : float, default=None
+        Significance level of the test.
+    power : float, default=None
+        Statistical power.
+    alternative : {'two-sided', 'greater', 'less'}
+        Direction of the alternative hypothesis.
+    """
+
     def __init__(
         self,
         h: float | None,
@@ -277,6 +355,12 @@ class WpTwoPropTwoN:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing the effect size, n1, n2, alpha, power, alternative hypothesis, and test metadata.
+        """
         if self.power is None:
             if self.h is None or self.n1 is None or self.n2 is None or self.alpha is None:
                 raise ValueError("h, n1, n2, and alpha must be provided to compute power")

--- a/webpower/randomized_trial_classes.py
+++ b/webpower/randomized_trial_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for cluster- and multisite-randomized trials."""
+
 from math import ceil, sqrt
 
 from scipy.stats import f as f_dist
@@ -8,6 +10,44 @@ from webpower.utils import nuniroot
 
 
 class WpMRT2Arm:
+    """Power analysis for two-arm multisite randomized trials (MRT).
+
+    Multisite randomized trials (MRT) are a type of multilevel design for the situation when the entire cluster is
+    randomly assigned to either a treatment arm or a control arm (Liu, 2013). This class is for designs with 2 arms
+    (i.e., a treatment and a control). Three types of tests are considered: the "main" type tests treatment main
+    effect; the "site" type tests the variance of cluster/site means; and the "variance" type tests variance of
+    treatment effects.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size. It is the number of individuals within each cluster.
+    f : float, default=None
+        Effect size. It specifies the main effect of treatment, the mean difference between the treatment
+        clusters/sites and the control clusters/sites. Effect size must be positive.
+    J : int, default=None
+        Number of clusters / sites. It tells how many clusters are considered in the study design. At least two
+        clusters are required.
+    tau00 : float, default=1.0
+        Variance of cluster/site means. It is one of the residual variances in the second level. Its value must be
+        positive.
+    tau11 : float, default=1.0
+        Variance of treatment effects across sites. It is one of the residual variances in the second level. Its value
+        must be positive.
+    sg2 : float, default=1.0
+        Level-one error Variance. The residual variance in the first level.
+    power : float, default=None
+        Statistical power
+    alpha : float, default=0.05
+        Significance level chosen for the test.
+    alternative : str, default='two-sided'
+        Type of alternative hypothesis. The option 'one-sided' can be either 'less' or 'greater'
+    test_type : str, default='main'
+        Type of effect. The type "main" tests treatment main effect, no tau00 needed; Type "site" tests the variance of
+        cluster/site means, no tau11 or f needed; and Type "variance" tests variance of treatment effects, no tau00 or
+        f needed.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -107,6 +147,12 @@ class WpMRT2Arm:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing J, n, the effect size, tau00, tau11, sg2, power, alpha and test metadata.
+        """
         if self.power is None:
             if self.J is None or self.n is None:
                 raise ValueError("J and n must be provided to compute power")
@@ -145,6 +191,41 @@ class WpMRT2Arm:
 
 
 class WpMRT3Arm:
+    """Power analysis for three-arm multisite randomized trials (MRT).
+
+    Multisite randomized trials (MRT) are a type of multilevel design for the situation when the entire cluster is
+    randomly assigned to either a treatment arm or a control arm (Liu, 2013). This class is for designs with 3 arms
+    (i.e., two treatments and a control). Three types of tests are considered: the "main" type tests treatment main
+    effect; the "treatment" type tests the difference between the two treatments; and the "omnibus" type tests whether
+    the three arms are all equivalent.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size. It is the number of individuals within each cluster.
+    f1 : float, default=None
+        Effect size for treatment main effect. Effect size must be positive.
+    f2 : float, default=0.0
+        Effect size for the difference between two treatments. Effect size must be positive.
+    J : int, default=None
+        Number of clusters / sites. It tells how many clusters are considered in the study design. At least two
+        clusters are required.
+    tau : float, default=1.0
+        Variance of treatment effects across sites/clusters.
+    sg2 : float, default=1.0
+        Level-one error Variance. The residual variance in the first level.
+    power : float, default=None
+        Statistical power
+    alpha : float, default=0.05
+        Significance level chosen for the test. It equals 0.05 by default.
+    alternative : str, default='two-sided'
+        Type of the alternative hypothesis. The option "one-sided" can be either "less" or "greater"
+    test_type : str, default='main'
+        The type "main" tests the difference between the average treatment arms and the control arm; Type "treatment"
+        tests the difference between the two treatment arms; and Type "omnibus" tests whether the three arms are all
+        equivalent.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -279,6 +360,12 @@ class WpMRT3Arm:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing power, J, n, f1, f2, alpha, tau, sg2 and test metadata.
+        """
         if self.power is None:
             if self.J is None or self.n is None or self.f1 is None:
                 raise ValueError("J, n, and f1 must be provided to compute power")
@@ -314,6 +401,34 @@ class WpMRT3Arm:
 
 
 class WpCRT2Arm:
+    """Power analysis for two-arm cluster randomized trials (CRT).
+
+    Cluster randomized trials (CRT) are a type of multilevel design for the situation when the entire cluster is
+    randomly assigned to either a treatment arm or a control arm (Liu, 2013). This class is for designs with 2 arms
+    (i.e., a treatment and a control). Details leading to power calculation can be found in Raudenbush (1997) and Liu
+    (2013).
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size. It is the number of individuals within each cluster
+    f : float, default=None
+        Effect size. It specifies either the main effect of treatment, or the mean difference between the treatment
+        clusters and the control clusters.
+    J : int, default=None
+        Number of clusters / sides. It tells how many clusters are considered in the study design. At least 2 clusters
+        are required.
+    icc : float, default=None
+        Intra-class correlation. ICC is calculated as the ratio of betwee-cluster variance to the total variance. It
+        quantifies the degree to which two randomly drawn observations within a cluster are correlated.
+    power : float, default=None
+        Statistical power
+    alpha : float, default=None
+        Significance level chosen for the test.
+    alternative : str, default='two-sided'
+        Type of alternative hypothesis. The option "one-sided" can be either "less" or "greater"
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -402,6 +517,12 @@ class WpCRT2Arm:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing J, n, the effect size, icc, power, alpha, the alternative hypothesis and metadata.
+        """
         if self.power is None:
             if self.J is None or self.f is None or self.icc is None or self.n is None or self.alpha is None:
                 raise ValueError("J, f, icc, n, and alpha must be provided to compute power")
@@ -446,6 +567,38 @@ class WpCRT2Arm:
 
 
 class WpCRT3Arm:
+    """Power analysis for three-arm cluster randomized trials (CRT).
+
+    Cluster randomized trials (CRT) are a type of multilevel design for the situation when the entire cluster is
+    randomly assigned to either a treatment arm or a control arm (Liu, 2013). This class is for designs with 3 arms
+    (i.e., two treatments and a control). Details leading to power calculation can be found in Raudenbush (1997) and Liu
+    (2013).
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size. It is the number of individuals within each cluster
+    f : float, default=None
+        Effect size. It specifies either the main effect of treatment, or the mean difference between the treatment
+        clusters and the control clusters.
+    J : int, default=None
+        Number of clusters / sides. It tells how many clusters are considered in the study design. At least 2 clusters
+        are required.
+    icc : float, default=None
+        Intra-class correlation. ICC is calculated as the ratio of betwee-cluster variance to the total variance. It
+        quantifies the degree to which two randomly drawn observations within a cluster are correlated.
+    power : float, default=None
+        Statistical power
+    alpha : float, default=None
+        Significance level chosen for the test.
+    alternative : str, default='two-sided'
+        Type of alternative hypothesis. The option "one-sided" can be either "less" or "greater"
+    test_type : str, default='main'
+        Type of effect. "main" tests the difference between the average treatment arms and the control arm; "treatment"
+        tests the difference between the two treatment arms; and "omnibus" tests whether the three arms are all
+        equivalent.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -620,6 +773,12 @@ class WpCRT3Arm:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing J, n, the effect size, icc, power, alpha and test metadata.
+        """
         if self.power is None:
             if self.J is None or self.f is None or self.icc is None or self.n is None or self.alpha is None:
                 raise ValueError("J, f, icc, n, and alpha must be provided to compute power")

--- a/webpower/regression_classes.py
+++ b/webpower/regression_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for regression models."""
+
 from math import ceil, exp, log, sqrt
 
 import numpy as np
@@ -9,6 +11,35 @@ from webpower.utils import brentq
 
 
 class WPRegression:
+    """Power analysis for linear regression models.
+
+    Regression is a statistical technique for examining the relationship between one or more independent variables
+    (or predictors) and one dependent variable (or the outcome). Regression provides an F-statistic that can be
+    formulated using the ratio between variation in the outcome variable that is explained by the predictors and the
+    unexplained variation (Cohen, 1988). The test statistic can also be expressed in terms of comparison between Full
+    and Reduced models (Maxwell & Delaney, 2003).
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size.
+    p1 : int, default=1
+        Number of predictors in the full model.
+    p2 : int, default=0
+        Number of predictors in the reduced model, it is 0 by default. See the book by Maxwell and Delaney (2003)
+        for the definition of the reduced model.
+    f2 : float, default=None
+        Effect size. We use the statistic f2 as the measure of effect size for linear regression proposed by Cohen
+        (1988, p.410). Cohen discussed the effect size in three different cases. The calculation of f2 can be
+        generalized using the idea of a full model and a reduced model by Maxwell and Delaney (2003).
+    alpha : float, default=None
+        Significance level chosen for the test.
+    power : float, default=None
+        Statistical power.
+    test_type : str, default="regular"
+        If set to "cohen", the formula used in the Cohen's book will be used (not recommended).
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -67,6 +98,12 @@ class WPRegression:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing the effect size, n, p1, p2, alpha, power, and test metadata.
+        """
         if self.power is None:
             if self.n is None or self.f2 is None or self.alpha is None:
                 raise ValueError("n, f2, and alpha must be provided to compute power")
@@ -99,6 +136,38 @@ class WPRegression:
 
 
 class WpPoisson:
+    """Power analysis for Poisson regression models.
+
+    Poisson regression is a type of generalized linear models where the outcomes are usually count data. Here,
+    Maximum likelihood methods is used to estimate the model parameters. The estimated regression coefficient is
+    assumed to follow a normal distribution. A Wald test is used to test the mean difference between the estimated
+    parameter and the null parameter (typically the null hypothesis assumes it equals 0). The procedure introduced
+    by Demidenko (2007) is adopted here for computing the statistical power.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size.
+    exp0 : float, default=1
+        The base rate under the null hypothesis. It always takes positive value. See the article by Demidenko (2007)
+        for details.
+    exp1 : float, default=0.5
+        The relative increase of the event rate. It is used for calculation of the effect size. See the article by
+        Demidenko (2007) for details.
+    alpha : float, default=None
+        Significance level of the test.
+    power : float, default=None
+        Statistical power.
+    alternative : str, default="two-sided"
+        Direction of the alternative hypothesis. One of "two-sided", "greater", or "less".
+    family : str, default="Bernoulli"
+        Distribution of the predictor. One of "bernoulli", "exponential", "lognormal", "normal", "poisson", or
+        "uniform".
+    parameter : int, float, list or tuple, default=None
+        Corresponding parameter for the predictor's distribution. The default is 0.5 for "bernoulli", 1 for
+        "exponential", (0,1) for "lognormal" or normal, 1 for "poisson", and (0,1) for "uniform".
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -254,6 +323,12 @@ class WpPoisson:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, power, alpha, exp0, exp1, beta0, beta1, and test metadata.
+        """
         if self.power is None:
             if self.n is None or self.alpha is None:
                 raise ValueError("n and alpha must be provided to compute power")
@@ -282,6 +357,36 @@ class WpPoisson:
 
 
 class WpLogistic:
+    """Power analysis for logistic regression models.
+
+    Logistic regression is a type of generalized linear models where the outcome variable follows Bernoulli
+    distribution. Here, Maximum likelihood methods is used to estimate the model parameters. The estimated
+    regression coefficient is assumed to follow a normal distribution. A Wald test is used to test the mean
+    difference between the estimated parameter and the null parameter (typically the null hypothesis assumes it
+    equals 0). The procedure introduced by Demidenko (2007) is adopted here for computing the statistical power.
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size.
+    p0 : float, default=0.5
+        Prob(Y=1|X=0): the probability of observing 1 for the outcome variable Y when the predictor X equals 0.
+    p1 : float, default=0.5
+        Prob(Y=1|X=1): the probability of observing 1 for the outcome variable Y when the predictor X equals 1.
+    alpha : float, default=None
+        Significance level chosen for the test.
+    power : float, default=None
+        Statistical power.
+    alternative : str, default="two-sided"
+        Direction of the alternative hypothesis. One of "two-sided", "greater", or "less".
+    family : str, default="Bernoulli"
+        Distribution of the predictor. One of "bernoulli", "exponential", "lognormal", "normal", "poisson", or
+        "uniform".
+    parameter : int, float, list or tuple, default=None
+        Corresponding parameter for the predictor's distribution. The default is 0.5 for "bernoulli", 1 for
+        "exponential", (0,1) for "lognormal" or normal, 1 for "poisson", and (0,1) for "uniform".
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -617,6 +722,12 @@ class WpLogistic:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, power, alpha, p0, p1, beta0, beta1, and test metadata.
+        """
         if self.power is None:
             if self.n is None or self.alpha is None:
                 raise ValueError("n and alpha must be provided to compute power")

--- a/webpower/sem_classes.py
+++ b/webpower/sem_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for structural equation modeling (SEM)."""
+
 from math import ceil
 
 from scipy.stats import chi2, ncx2
@@ -6,6 +8,29 @@ from webpower.utils import brentq
 
 
 class WPSEMChisq:
+    """Power analysis for structural equation modeling (SEM) based on the chi-squared test.
+
+    Structural equation modeling (SEM) is a multivariate technique used to analyze relationships among observed and
+    latent variables. This class implements SEM power analysis based on the likelihood ratio test proposed by Satorra
+    and Saris (1985).
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size
+    df : int, default=None
+        The degrees of freedom for our test, based on the Chi-Squared Test.
+    effect : float, default=None
+        Effect size. It specifies the population misfit of a SEM model, which is the difference between two SEM models:
+        a full model (Mf) and a reduced model (Mr). A convienient way to get the effect size is to fit the reduced model
+        using SEM software such R package 'lavaan' (Rossel, 2012). Then the effect size is calculated as the
+        chi-squared statistics dividing by the sample size.
+    alpha : float, default=None
+        Significance level chosen for the test.
+    power : float, default=None
+        Statistical power.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -53,6 +78,12 @@ class WPSEMChisq:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, df, effect_size, alpha, power, and the method and url metadata of the test.
+        """
         if self.power is None:
             if self.n is None or self.effect is None or self.df is None or self.alpha is None:
                 raise ValueError("n, effect, df, and alpha must be provided to compute power")
@@ -89,6 +120,29 @@ class WPSEMChisq:
 
 
 class WPSEMRMSEA:
+    """Power analysis for structural equation modeling (SEM) based on RMSEA.
+
+    Structural equation modeling (SEM) is a multivariate technique used to analyze relationships among observed and
+    latent variables. This class implements SEM power analysis based on RMSEA proposed by MacCallum et al. (1996).
+
+    Parameters
+    ----------
+    n : int, default=None
+        Sample size
+    df : int, default=None
+        The degrees of freedom for our test, based on the Chi-Squared Test.
+    rmsea0 : float, default=None
+        The RMSE for H0. It usually equals 0.
+    rmsea1 : float, default=None
+        The RMSE for H1
+    power : float, default=None
+        Statistical power.
+    alpha : float, default=None
+        Significance level chosen for the test.
+    test_type : {'close', 'notclose'}, default='close'
+        Close fit or not-close fit.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -170,6 +224,12 @@ class WPSEMRMSEA:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, df, rmsea0, rmsea1, alpha, power, and the method and url metadata of the test.
+        """
         if self.power is None:
             if self.n is None or self.df is None or self.rmsea0 is None or self.rmsea1 is None or self.alpha is None:
                 raise ValueError("n, df, rmsea0, rmsea1, and alpha must be provided to compute power")

--- a/webpower/t_test_classes.py
+++ b/webpower/t_test_classes.py
@@ -1,3 +1,5 @@
+"""Power-analysis classes for t-tests."""
+
 from math import ceil, sqrt
 
 from scipy.stats import nct
@@ -7,6 +9,29 @@ from webpower.utils import brentq
 
 
 class WpOneT:
+    """Power analysis for a one-sample or paired t-test.
+
+    A t-test is a statistical hypothesis test in which the test statistic follows a Student's t distribution if the
+    null hypothesis is true and follows a non-central t distribution if the alternative hypothesis is true. The t test
+    can assess the statistical significance of (1) the difference between population mean and a specific value, (2) the
+    difference between two independent population means, and (3) difference between means of matched pairs.
+
+    Parameters
+    ----------
+    n : int, default=None
+        If test_type='one-sample', then the sample size of our group; otherwise the sample size of both groups.
+    d : float, default=None
+        Effect size
+    alpha : float, default=None
+        Significance level of the test.
+    power : float, default=None
+        Statistical power.
+    test_type : {'two-sample', 'paired', 'one-sample'}, default='two-sample'
+        Whether our test is a two-sample test, a paired test or a one-sample test.
+    alternative : {'two-sided', 'greater', 'less'}, default='two-sided'
+        Direction of the alternative hypothesis.
+    """
+
     def __init__(
         self,
         n: int | None = None,
@@ -107,6 +132,12 @@ class WpOneT:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing n, effect_size, alpha, power, our alternative hypothesis and test metadata.
+        """
         if self.power is None:
             if self.n is None or self.d is None or self.alpha is None:
                 raise ValueError("n, d, and alpha must be provided to compute power")
@@ -155,6 +186,29 @@ class WpOneT:
 
 
 class WpTwoT:
+    """Power analysis for a two-sample t-test.
+
+    A t-test is a statistical hypothesis test in which the test statistic follows a Student's t distribution if the
+    null hypothesis is true and follows a non-central t distribution if the alternative hypothesis is true. The t test
+    can assess the statistical significance of (1) the difference between population mean and a specific value, (2) the
+    difference between two independent population means, and (3) difference between means of matched pairs.
+
+    Parameters
+    ----------
+    n1 : int, default=None
+        The sample size of our first group
+    n2 : int, default=None
+        The sample size of our second group
+    d : float, default=None
+        Effect size
+    alpha : float, default=None
+        Significance level of the test.
+    power : float, default=None
+        Statistical power.
+    alternative : {'two-sided', 'greater', 'less'}, default='two-sided'
+        Direction of the alternative hypothesis.
+    """
+
     def __init__(
         self,
         n1: int | None = None,
@@ -310,6 +364,12 @@ class WpTwoT:
         return float(result)
 
     def pwr_test(self) -> dict:
+        """Solve for the unspecified parameter and return the power-analysis results.
+
+        Returns
+        -------
+        A dictionary containing effect_size, n1, n2, alpha, power, our alternative hypothesis and test metadata.
+        """
         if self.power is None:
             if self.n1 is None or self.n2 is None or self.d is None or self.alpha is None:
                 raise ValueError("n1, n2, d, and alpha must be provided to compute power")

--- a/webpower/utils.py
+++ b/webpower/utils.py
@@ -1,3 +1,5 @@
+"""Numerical helper utilities used across the power-analysis classes."""
+
 from collections.abc import Callable
 
 import numpy as np
@@ -6,15 +8,45 @@ from scipy.optimize import brentq as _scipy_brentq
 
 
 def bisect(f: Callable[[float], float], a: float, b: float) -> float:
+    """Find a root of ``f`` on the bracketing interval ``[a, b]`` using bisection.
+
+    Parameters
+    ----------
+    f : function
+        The function whose root we are solving for
+    a : float
+        The low end of the bracketing interval
+    b : float
+        The high end of the bracketing interval
+
+    Returns
+    -------
+    The root of ``f`` between ``a`` and ``b``
+    """
     return _scipy_bisect(f, a, b)  # type: ignore[return-value]
 
 
 def brentq(f: Callable[[float], float], a: float, b: float) -> float:
+    """Find a root of ``f`` on the bracketing interval ``[a, b]`` using Brent's method.
+
+    Parameters
+    ----------
+    f : function
+        The function whose root we are solving for
+    a : float
+        The low end of the bracketing interval
+    b : float
+        The high end of the bracketing interval
+
+    Returns
+    -------
+    The root of ``f`` between ``a`` and ``b``
+    """
     return _scipy_brentq(f, a, b)  # type: ignore[return-value]
 
 
 def nuniroot(f: Callable[[float], float], low_val: float = 0, high_val: float = 1, max_length: int = 100) -> float:
-    """Calculates the root of our function f given low_val and high_val.
+    """Calculate the root of our function f given low_val and high_val.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary

Enables ruff's pydocstyle (`D`) rules with `convention = "numpy"` and backfills docstrings across the `webpower` package so the convention is fully enforced.

## Changes

- **Config** (`pyproject.toml`): added `D` to `select`, set `[tool.ruff.lint.pydocstyle] convention = "numpy"`, and exempted `test/*` from docstring rules.
- **Module docstrings** (`D100`): all 9 `webpower` modules.
- **Class docstrings** (`D101`): all 21 power-analysis classes, with `Parameters` sections matching each `__init__`.
- **Method docstrings** (`D102`): all 20 public `pwr_test` methods, with `Returns` sections reflecting the actual return dict.
- **Function docstrings** (`D103`): `bisect` / `brentq` helpers in `utils.py`.
- **Style fixes** (`D205`/`D401`/`D404`): existing docstrings in `power_tests.py` given imperative summary lines.

Class/method docs reuse the parameter wording already present in `power_tests.py` to stay consistent with the public API.

## Verification

- `ruff check .` → All checks passed (no suppressions for `webpower`)
- `ruff format --check .` → clean
- Package imports OK (no logic changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)