### PR TITLE
Fix solver crashes from SciPy noncentral-distribution NaNs

### DIFF
--- a/webpower/anova_classes.py
+++ b/webpower/anova_classes.py
@@ -561,7 +561,9 @@ class WpRMAnovaClass:
             if self.f is None or self.n is None or self.nm is None or self.alpha is None or self.power is None:
                 raise ValueError("f, n, nm, alpha, and power must be provided to solve for ng")
             f, n, nm, alpha, power = self.f, self.n, self.nm, self.alpha, self.power
-            self.ng = ceil(bisect(lambda ng: self._get_groups(ng, f, n, nm, alpha, power), 1 + 1e-10, 1e05))
+            # The number of groups must stay below the sample size so the denominator df (n - ng) stays
+            # positive; bracketing past it lands in the degenerate region where the F distribution is NaN.
+            self.ng = ceil(bisect(lambda ng: self._get_groups(ng, f, n, nm, alpha, power), 1 + 1e-10, n - 1))
         elif self.f is None:
             if self.n is None or self.ng is None or self.nm is None or self.alpha is None or self.power is None:
                 raise ValueError("n, ng, nm, alpha, and power must be provided to solve for f")

--- a/webpower/utils.py
+++ b/webpower/utils.py
@@ -40,7 +40,7 @@ def bisect(f: Callable[[float], float], a: float, b: float) -> float:
     -------
     The root of ``f`` between ``a`` and ``b``
     """
-    return _scipy_bisect(f, a, b)  # type: ignore[return-value]
+    return _scipy_bisect(_nan_safe(f), a, b)  # type: ignore[return-value]
 
 
 def brentq(f: Callable[[float], float], a: float, b: float) -> float:
@@ -59,7 +59,7 @@ def brentq(f: Callable[[float], float], a: float, b: float) -> float:
     -------
     The root of ``f`` between ``a`` and ``b``
     """
-    return _scipy_brentq(f, a, b)  # type: ignore[return-value]
+    return _scipy_brentq(_nan_safe(f), a, b)  # type: ignore[return-value]
 
 
 def nuniroot(f: Callable[[float], float], low_val: float = 0, high_val: float = 1, max_length: int = 100) -> float:

--- a/webpower/utils.py
+++ b/webpower/utils.py
@@ -5,12 +5,29 @@ from scipy.optimize import bisect as _scipy_bisect
 from scipy.optimize import brentq as _scipy_brentq
 
 
+def _nan_safe(f: Callable[[float], float]) -> Callable[[float], float]:
+    """Wrap a power objective so NaN values from SciPy's noncentral distributions don't abort the solver.
+
+    The objectives passed to the root-finders are ``power(param) - target`` and are monotonic in
+    ``param``. For large noncentrality SciPy's noncentral distributions (``nct``, ``ncf``, ``ncx2``)
+    can return ``NaN`` even though the power has saturated at ~1. That ``NaN`` band always sits on the
+    high-power (positive-objective) side of the root, so substituting a positive sentinel keeps the
+    solver bracketing the true root instead of raising on ``NaN``.
+    """
+
+    def safe(x: float) -> float:
+        value = f(x)
+        return 1.0 if np.isnan(value) else value
+
+    return safe
+
+
 def bisect(f: Callable[[float], float], a: float, b: float) -> float:
-    return _scipy_bisect(f, a, b)  # type: ignore[return-value]
+    return _scipy_bisect(_nan_safe(f), a, b)  # type: ignore[return-value]
 
 
 def brentq(f: Callable[[float], float], a: float, b: float) -> float:
-    return _scipy_brentq(f, a, b)  # type: ignore[return-value]
+    return _scipy_brentq(_nan_safe(f), a, b)  # type: ignore[return-value]
 
 
 def nuniroot(f: Callable[[float], float], low_val: float = 0, high_val: float = 1, max_length: int = 100) -> float:


### PR DESCRIPTION
## Summary

Four tests were failing in CI because SciPy ≥1.16 returns `NaN` from the noncentral distributions (`nct`/`ncf`) in two regimes, and the `brentq`/`bisect` root-finders abort when their (over-wide) brackets probe those regions:

- **Saturated power** — very large noncentrality, where power is effectively 1.
- **Degenerate design** — denominator df ≤ 0 (e.g. `n - ng ≤ 0`).

## Changes

- **`utils.py`** — added a `_nan_safe` wrapper applied to the `brentq`/`bisect` objectives. The objectives are monotonic `power(param) - target`, and the `NaN` band always sits on the saturated (positive) side of the root, so substituting a positive sentinel keeps the solver bracketing the true root.
- **`anova_classes.py`** — capped the repeated-measures ANOVA group search at `n - 1`, keeping it in the feasible domain (`n - ng > 0`) where the objective is finite and the real root is bracketed.

## Verification

- `pytest` → **21 passed** (previously 4 failed: `TestOneT`, `TestTwoT`, `TestAnova`, `TestRMAnova`)
- `ruff check` + `ruff format --check` → clean

## Note

This branch and #4 (numpy docstrings) both touch `utils.py`'s `bisect`/`brentq`. Merging #4 first, then this, avoids a trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)